### PR TITLE
Add ./ as shared folder, and remove reboot instruction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ After checking out this repo, boot up the VM in Vagrant:
 
 ```text
 vagrant up
+vagrant reload # required to reboot after installing new kernel
 ```
 
 If you are using VirtualBox > 4.2.0 you will probably need to update the Guest

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,7 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "precise64"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.synced_folder "./", "/vagrant"
 
   config.vm.provision :shell, inline: <<-SCRIPT
     sudo -u vagrant sh -c "echo 'export GOPATH=/vagrant' >> /home/vagrant/.bashrc"
@@ -16,6 +17,5 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # install latest kernel
     apt-get update
     apt-get install -y linux-image-generic-lts-raring linux-headers-generic-lts-raring make
-    reboot
   SCRIPT
 end


### PR DESCRIPTION
Rebooting the VM in the provisioning step will make the shared folder go away, and then ssh'ing to the VM will show an empty /vagrant folder. Better to explicitly `vagrant reload`, then everything works fine.
