### PR TITLE
Use Phusion's Docker-friendly Vagrant base box.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This repo contains a Vagrantfile/Makefile combo that set up all of the Flynn
 components and dependencies in a working dev/test configuration.
 
 The only requirement is that you have [VirtualBox](https://www.virtualbox.org/)
-and [Vagrant](http://www.vagrantup.com/) installed.
+and [Vagrant](http://www.vagrantup.com/) installed. We use Phusion's [Docker-friendly Vagrant box](http://blog.phusion.nl/2013/11/08/docker-friendly-vagrant-boxes/)
+as Vagrant base box, tested on VirtualBox 4.2.18.
 
 **Note:** Flynn is alpha-quality software, so things are probably broken.
 
@@ -18,17 +19,6 @@ After checking out this repo, boot up the VM in Vagrant:
 
 ```text
 vagrant up
-vagrant reload # required to reboot after installing new kernel
-```
-
-If you are using VirtualBox > 4.2.0 you will probably need to update the Guest
-Additions with [vagrant-vbguest](https://github.com/dotless-de/vagrant-vbguest):
-
-```
-vagrant up
-vagrant plugin install vagrant-vbguest
-vagrant vbguest
-vagrant reload
 ```
 
 After the VM provisioning has finished, log in to it and run `make` to install

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ This repo contains a Vagrantfile/Makefile combo that set up all of the Flynn
 components and dependencies in a working dev/test configuration.
 
 The only requirement is that you have [VirtualBox](https://www.virtualbox.org/)
-and [Vagrant](http://www.vagrantup.com/) installed. We use Phusion's [Docker-friendly Vagrant box](http://blog.phusion.nl/2013/11/08/docker-friendly-vagrant-boxes/)
-as Vagrant base box, tested on VirtualBox 4.2.18.
+and [Vagrant](http://www.vagrantup.com/) installed.
 
 **Note:** Flynn is alpha-quality software, so things are probably broken.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,10 +2,13 @@
 # vi: set ft=ruby :
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+#
+# We use Phusion's[Docker-friendly Vagrant box (http://blog.phusion.nl/2013/11/08/docker-friendly-vagrant-boxes/)
+# as Vagrant base box
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "phusion_ubuntu_12_04"
+  config.vm.box = "phusion_precise64"
   config.vm.box_url = "https://oss-binaries.phusionpassenger.com/vagrant/boxes/ubuntu-12.04.3-amd64-vbox.box"
   config.vm.synced_folder "./", "/vagrant"
 
@@ -13,9 +16,5 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     sudo -u vagrant sh -c "echo 'export GOPATH=/vagrant' >> /home/vagrant/.bashrc"
     sudo -u vagrant sh -c "echo 'PATH=/vagrant/bin:$PATH' >> /home/vagrant/.bashrc"
     sudo -u vagrant sh -c "echo 'cd /vagrant' >> /home/vagrant/.bashrc"
-
-    # install latest kernel
-    apt-get update
-    apt-get install -y make
   SCRIPT
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,8 +5,8 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "precise64"
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.box = "phusion_ubuntu_12_04"
+  config.vm.box_url = "https://oss-binaries.phusionpassenger.com/vagrant/boxes/ubuntu-12.04.3-amd64-vbox.box"
   config.vm.synced_folder "./", "/vagrant"
 
   config.vm.provision :shell, inline: <<-SCRIPT
@@ -16,6 +16,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     # install latest kernel
     apt-get update
-    apt-get install -y linux-image-generic-lts-raring linux-headers-generic-lts-raring make
+    apt-get install -y make
   SCRIPT
 end


### PR DESCRIPTION
This PR swaps the default `precise64` Vagrant box for Phusion's [Docker-friendly Vagrant box](http://blog.phusion.nl/2013/11/08/docker-friendly-vagrant-boxes/).

Consequently, I've changed the following things:
- Removed the `vagrant plugin ...`, `vagrant vbguest`, and `vagrant reload` commands from the readme, as those are no longer needed. Phusion's box sees to the installation of the proper VirtualBox Guest Additions automatically, and does not need a reboot as no kernel updates are needed.
- Updated the Vagrantfile to use the new box, and removed the Linux kernel packages from the `apt-get` command, as the new box already ships with a Docker-ready kernel.
- I've named the new box `phusion_ubuntu_12_04`, so it is clear we are using the Phusion box as base, which itself is based on Ubuntu 12.04.

Tested on OS/X 10.9 with VirtualBox 4.2.18, which seems to work fine.
