### PR TITLE
Use socket connection for docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER=docker -H 127.0.0.1
+DOCKER=docker -H=unix:///var/run/docker.sock
 
 run: all
 	bin/forego start


### PR DESCRIPTION
I just installed the VM and it seems that docker is not accessible via TCP but via socket.
